### PR TITLE
searchForMembers, properly encode request values

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 5.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- In searchForMembers, ensure that request parameters are properly
+  decoded to unicode
+  [do3cc]
 
 
 5.0 (2014-04-05)

--- a/Products/PlonePAS/tests/test_membershiptool.py
+++ b/Products/PlonePAS/tests/test_membershiptool.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import os
 import unittest
 from cStringIO import StringIO
@@ -10,6 +11,7 @@ from Acquisition import aq_parent
 from DateTime import DateTime
 from OFS.Image import Image
 from zExceptions import BadRequest
+from zope.component import getUtility
 
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.tests.base.testcase import WarningInterceptor
@@ -20,6 +22,7 @@ from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import PLONE_SITE_ID
 
+from Products.CMFCore.interfaces import IPropertiesTool
 from Products.PlonePAS.interfaces.membership import IMembershipTool
 from Products.PlonePAS.browser.member import PASMemberView
 from Products.PlonePAS.plugins.ufactory import PloneUser
@@ -824,6 +827,20 @@ class TestSearchForMembers(base.TestCase, WarningInterceptor):
         search = self.membership.searchForMembers
         self.assertEqual(len(search(email='fred', roles=['Reviewer'])), 1)
         self.assertEqual(len(search(email='fred', roles=['Manager'])), 0)
+
+    def testSearchByRequestObj(self):
+        search = self.membership.searchForMembers
+        self.addMember(u'jürgen', u'Jürgen Internationalist',
+                       'juergen@example.com', ['Member'],
+                       '2014-02-03')
+
+        self.assertEqual(len(search(
+            REQUEST=dict(name=u'jürgen'))), 1)
+
+        ptool = getUtility(IPropertiesTool)
+        ptool._setProperty('default_charset', 'iso8859-1')
+        self.assertEqual(len(search(
+            REQUEST=dict(name=u'jürgen'.encode('iso8859-1')))), 1)
 
     def beforeTearDown(self):
         self._free_warning_output()

--- a/Products/PlonePAS/tools/membership.py
+++ b/Products/PlonePAS/tools/membership.py
@@ -21,6 +21,7 @@ from Acquisition import aq_parent
 from zExceptions import BadRequest
 from ZODB.POSException import ConflictError
 
+from Products.CMFDefault.utils import decode
 from Products.CMFCore.permissions import ManagePortal
 from Products.CMFCore.permissions import ManageUsers
 from Products.CMFCore.permissions import SetOwnProperties
@@ -163,6 +164,9 @@ class MembershipTool(BaseTool):
 
         if REQUEST is not None:
             searchmap = REQUEST
+            for key, value in searchmap.items():
+                if isinstance(value, basestring):
+                    searchmap[key] = decode(value, self)
         else:
             searchmap = kw
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ install_requires=[
         'plone.session',
         'plone.i18n',
         'Products.CMFCore',
+        'Products.CMFDefault',
         'Products.GenericSetup',
         'Products.PluggableAuthService',
         'Zope2 > 2.12.4',


### PR DESCRIPTION
searchForMembers did not check that request values are properly
encoded. Neither did the user folders below, resulting in undefined
search behavior for non ascii values.