### PR TITLE
Add back ordereddict (for python 2.6 support)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- bring back Python 2.6 support (in 2.6 depend on orderedict) and import
+  conditional with fallback.
+  [gforcada, jensens]
 
 
 5.0.5 (2015-12-08)

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,29 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 from setuptools import find_packages
+import sys
 
 version = '5.0.6.dev0'
 
 longdescription = open("README.rst").read()
 longdescription += '\n'
 longdescription += open("CHANGES.rst").read()
+
+install_requires = [
+        'plone.i18n',
+        'plone.memoize',
+        'plone.protect',
+        'plone.session',
+        'Products.CMFCore',
+        'Products.GenericSetup',
+        'Products.PluggableAuthService',
+        'setuptools',
+        'zope.deprecation',
+        'Zope2 >=2.13.22',
+    ],
+if sys.version_info < (2, 7):
+    # python 2.6 has no collections.ordereddict so we need to use this package
+    install_requires.append('ordereddict')
 
 setup(
     name='Products.PlonePAS',
@@ -27,19 +44,7 @@ setup(
     namespace_packages=['Products'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=[
-        'Products.CMFCore',
-        'Products.GenericSetup',
-        'Products.PluggableAuthService',
-        'Zope2 >=2.13.22',
-        'plone.i18n',
-        'plone.memoize',
-        'plone.session',
-        'setuptools',
-        'zope.deprecation',
-        'plone.protect',
-        'ordereddict',
-    ],
+    install_requires=install_requires,
     extras_require=dict(
         test=[
             'plone.app.testing',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
         'plone.session',
         'setuptools',
         'zope.deprecation',
-        'plone.protect'
+        'plone.protect',
+        'ordereddict',
     ],
     extras_require=dict(
         test=[

--- a/src/Products/PlonePAS/plugins/ufactory.py
+++ b/src/Products/PlonePAS/plugins/ufactory.py
@@ -12,8 +12,12 @@ from Products.PluggableAuthService.interfaces.plugins import IUserFactoryPlugin
 from Products.PluggableAuthService.interfaces.propertysheets \
     import IPropertySheet
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
-from collections import OrderedDict
 from zope.interface import implementer
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 manage_addPloneUserFactoryForm = DTMLFile('../zmi/PloneUserFactoryForm',
                                           globals())


### PR DESCRIPTION
As Products.PlonePAS 5.x is being used on Plone 4.x python 2.6 support is expected.