### PR TITLE
Let cleanId return a string when getting a unicode.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ New:
 
 Fixes:
 
+- Let ``cleanId`` return a string when getting a unicode.  [maurits]
+
 - Fixed AttributeError with Python 2.6 when reading setup.py.  [maurits]
 
 

--- a/src/Products/PlonePAS/tests/test_membershiptool.py
+++ b/src/Products/PlonePAS/tests/test_membershiptool.py
@@ -114,6 +114,10 @@ class MembershipToolTest(base.TestCase):
         ac = zip(a, c)
         for aa, cc in ac:
             self.assertTrue(aa == cc)
+        cleaned = cleanId(u'abc')
+        self.assertEqual(cleaned, 'abc')
+        self.assertTrue(isinstance(cleaned, str))
+        self.assertFalse(isinstance(cleaned, unicode))
 
 
 class MemberAreaTest(base.TestCase):

--- a/src/Products/PlonePAS/utils.py
+++ b/src/Products/PlonePAS/utils.py
@@ -23,6 +23,8 @@ def cleanId(id):
     __traceback_info__ = (id,)
     if id:
         # note: we provide the 'safe' param to get '/' encoded
+        if isinstance(id, unicode):
+            id = id.encode('utf-8')
         return url_quote(id, '').replace('-', '--').replace('%', '-')
     return ''
 


### PR DESCRIPTION
This is needed for https://github.com/plone/buildout.coredev/pull/176.
But let's test it on its own too, in coredev 4.3 and 5.0.