### PR TITLE
Use the _marker from CMFCore for MemberDataTool.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Use the _marker from CMFCore for MemberDataTool.getProperty,
+  this makes sure that we never return the _marker from PlonePAS
+  but an error.
+  [pcdummy]
 
 
 5.0.10 (2016-05-02)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ Bug fixes:
   but an error.
   [pcdummy]
 
+- Don't raise an ValueError if a property doesn't exists for a ZOPE
+  user.
+  [pcdummy]
+
 
 5.0.10 (2016-05-02)
 -------------------

--- a/src/Products/PlonePAS/tools/memberdata.py
+++ b/src/Products/PlonePAS/tools/memberdata.py
@@ -4,6 +4,7 @@ from AccessControl.requestmethod import postonly
 from Acquisition import aq_base
 from App.class_init import InitializeClass
 from Products.BTreeFolder2.BTreeFolder2 import BTreeFolder2
+from Products.CMFCore.MemberDataTool import _marker
 from Products.CMFCore.MemberDataTool import MemberData as BaseMemberData
 from Products.CMFCore.MemberDataTool import MemberDataTool as BaseTool
 from Products.CMFCore.permissions import ManagePortal
@@ -22,8 +23,6 @@ from Products.PluggableAuthService.interfaces.plugins import IPropertiesPlugin
 from Products.PluggableAuthService.interfaces.plugins import \
     IRoleAssignerPlugin
 from zope.interface import implementer
-
-_marker = object()
 
 
 class MemberDataTool(BaseTool):

--- a/src/Products/PlonePAS/tools/memberdata.py
+++ b/src/Products/PlonePAS/tools/memberdata.py
@@ -301,7 +301,13 @@ class MemberData(BaseMemberData):
             # we won't always have PlonePAS users, due to acquisition,
             # nor are guaranteed property sheets
             if not sheets:
-                return BaseMemberData.getProperty(self, id, default)
+                try:
+                    return BaseMemberData.getProperty(self, id, default)
+                except ValueError:
+                    # Zope users don't have PropertySheets,
+                    # return an empty string for them if the property
+                    # doesn't exists.
+                    return ''
 
         # If we made this far, we found a PAS and some property sheets.
         for sheet in sheets:


### PR DESCRIPTION
Without using the _marker from CMFCore an unknown property results in beeing the _marker from PlonePAS.

This fix makes sure that we never return the _marker from PlonePAS but use the same object in both as default.

Signed-off-by: Rene Jochum <rene@jochums.at>