### PR TITLE
Fix login on sites without a location property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- In getMemberInfo, if a property is not present it now returns an
+  empty string, rather than raising an exception. This fixes login for
+  sites that have location removed.
+  [MatthewWilkes]
 
 
 5.0.12 (2016-09-09)

--- a/src/Products/PlonePAS/tests/test_membershiptool.py
+++ b/src/Products/PlonePAS/tests/test_membershiptool.py
@@ -557,6 +557,14 @@ class TestMembershipTool(base.TestCase, WarningInterceptor):
         info = self.membership.getMemberInfo('user2')
         self.assertEqual(info['fullname'], 'Second user')
 
+    def testGetMemberInfoWithMissingProperties(self):
+        self.membership.addMember('user3', 'secret', ['Member'], [],
+                                  properties={'fullname': 'Second user'})
+        self.membership.portal_memberdata._delProperty('location')
+        self.membership.portal_memberdata._delProperty('home_page')
+        info = self.membership.getMemberInfo('user3')
+        self.assertEqual(info['fullname'], 'Second user')
+
     def testGetCandidateLocalRolesIncludesLocalRolesOnObjectForManager(self):
         self.folder._addRole('my_test_role')
         self.folder.manage_setLocalRoles(TEST_USER_ID,
@@ -944,7 +952,7 @@ class TestMemberInfoView(base.TestCase):
         self.assertTrue(self.membership.isAnonymousUser())
         info = self.view.info()
         self.assertEqual(info['username'], 'Anonymous User')
-        self.assertEqual(info['fullname'], None)
+        self.assertEqual(info['fullname'], '')
         self.assertEqual(info['name_or_id'], 'Anonymous User')
 
     def testSetGroupsWithUserNameIdDifference(self):

--- a/src/Products/PlonePAS/tools/membership.py
+++ b/src/Products/PlonePAS/tools/membership.py
@@ -387,11 +387,11 @@ class MembershipTool(BaseTool):
             return None
 
         memberinfo = {
-            'fullname': member.getProperty('fullname'),
-            'description': member.getProperty('description'),
-            'location': member.getProperty('location'),
-            'language': member.getProperty('language'),
-            'home_page': member.getProperty('home_page'),
+            'fullname': member.getProperty('fullname', ''),
+            'description': member.getProperty('description', ''),
+            'location': member.getProperty('location', ''),
+            'language': member.getProperty('language', ''),
+            'home_page': member.getProperty('home_page', ''),
             'username': member.getUserName(),
             'has_email': bool(member.getProperty('email')),
         }


### PR DESCRIPTION
Fix https://github.com/plone/Products.CMFPlone/issues/1725

Allow log-in on sites that do not have a location membership property.