### PR TITLE
Report home_page as empty when it is suspicious. [5.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Report home_page as empty when it is suspicious.
+  It may for example contain javascript.
+  Part of PloneHotfix20171128.
+  [maurits]
 
 
 5.0.14 (2017-05-09)


### PR DESCRIPTION
It may for example contain javascript.
Part of PloneHotfix20171128.