### PR TITLE
Report home_page as empty when it is suspicious. [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Report home_page as empty when it is suspicious.
+  It may for example contain javascript.
+  Part of PloneHotfix20171128.
+  [maurits]
 
 
 5.0.14 (2017-05-09)

--- a/src/Products/PlonePAS/tools/membership.py
+++ b/src/Products/PlonePAS/tools/membership.py
@@ -387,12 +387,27 @@ class MembershipTool(BaseTool):
         if member is None:
             return None
 
+        # Special handling to avoid bad home_pages, like javascript.
+        home_page = member.getProperty('home_page', '')
+        if isinstance(home_page, basestring):
+            if (not home_page.startswith('https://') and
+                    not home_page.startswith('http://')):
+                # Suspicious.  But if it is internal, it is fine.
+                urltool = getToolByName(self, 'portal_url')
+                if not urltool.isURLInPortal(home_page):
+                    # We do not trust this url, so empty it.
+                    # It may for example be javascript.
+                    logger.warn(
+                        'Member %s has suspicious home_page property: %s',
+                        memberId, home_page)
+                    home_page = ''
+
         memberinfo = {
             'fullname': member.getProperty('fullname', ''),
             'description': member.getProperty('description', ''),
             'location': member.getProperty('location', ''),
             'language': member.getProperty('language', ''),
-            'home_page': member.getProperty('home_page', ''),
+            'home_page': home_page,
             'username': member.getUserName(),
             'has_email': bool(member.getProperty('email')),
         }


### PR DESCRIPTION
It may for example contain javascript.
Part of PloneHotfix20171128.