### PR TITLE
Feature: event for an account being deleted but still in the database

### DIFF
--- a/src/Products/PlonePAS/events.py
+++ b/src/Products/PlonePAS/events.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from Products.PlonePAS.interfaces.events import IPrincipalBeforeDeletedEvent
 from Products.PlonePAS.interfaces.events import IUserInitialLoginInEvent
 from Products.PluggableAuthService.events import PASEvent
 from Products.PluggableAuthService.interfaces.events import IUserLoggedInEvent
@@ -25,6 +26,14 @@ class UserInitialLoginInEvent(UserLoggedInEvent):
 @implementer(IUserLoggedOutEvent)
 class UserLoggedOutEvent(PASEvent):
     """Plone Implementation of the logged out event
+
+    PAS Event
+    """
+
+
+@implementer(IPrincipalBeforeDeletedEvent)
+class PrincipalBeforeDeleted(PASEvent):
+    """ Plone Implementation for an account marked to be deleted event
 
     PAS Event
     """

--- a/src/Products/PlonePAS/interfaces/events.py
+++ b/src/Products/PlonePAS/interfaces/events.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
+from Products.PluggableAuthService.interfaces.events import IPASEvent
 from Products.PluggableAuthService.interfaces.events import IUserLoggedInEvent
+
+
+class IPrincipalBeforeDeletedEvent(IPASEvent):
+    """A user is marked to be removed but still into database.
+    """
 
 
 class IUserInitialLoginInEvent(IUserLoggedInEvent):

--- a/src/Products/PlonePAS/pas.py
+++ b/src/Products/PlonePAS/pas.py
@@ -21,6 +21,7 @@ from Products.PluggableAuthService.PluggableAuthService import \
     PluggableAuthService
 from Products.PluggableAuthService.PluggableAuthService import \
     _SWALLOWABLE_PLUGIN_EXCEPTIONS
+from Products.PluggableAuthService.events import PrincipalBeforeDeleted
 from Products.PluggableAuthService.events import PrincipalDeleted
 from Products.PluggableAuthService.interfaces.authservice import \
     IPluggableAuthService
@@ -124,6 +125,8 @@ def _doDelUser(self, id):
         )
 
     for userdeleter_id, userdeleter in userdeleters:
+        notify(PrincipalBeforeDeleted(id))
+
         try:
             userdeleter.doDeleteUser(id)
         except _SWALLOWABLE_PLUGIN_EXCEPTIONS:


### PR DESCRIPTION
The problem/solution is described here: https://stackoverflow.com/questions/48297612/plone-notify-a-user-on-deleting-his-account/48302367

Please test my code, I just copy-pasted from my solution based on intuition. MrTango suggested to create a PR here, so here it is.