### PR TITLE
Notify PropertiesUpdated event when user properties are updated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,9 +7,6 @@ Changelog
 - Notify PropertiesUpdated event when member properties are changed
   [ezvirtual]
 
-- Add simple test for PropertiesUpdated event
-  [ezvirtual]
-
 
 5.0.15 (2017-12-11)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 5.0.16 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Notify PropertiesUpdated event when member properties are changed
+  [ezvirtual]
+
+- Add simple test for PropertiesUpdated event
+  [ezvirtual]
 
 
 5.0.15 (2017-12-11)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 from setuptools import find_packages
 import sys
 
-version = '5.0.16'
+version = '5.0.16.dev0'
 
 longdescription = open("README.rst").read()
 longdescription += '\n'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 from setuptools import find_packages
 import sys
 
-version = '5.0.16.dev0'
+version = '5.0.16'
 
 longdescription = open("README.rst").read()
 longdescription += '\n'

--- a/src/Products/PlonePAS/tests/test_memberdatatool.py
+++ b/src/Products/PlonePAS/tests/test_memberdatatool.py
@@ -102,7 +102,7 @@ class TestMemberDataTool(base.TestCase):
 
         # Test that notify(PropertiesUpdated) isn't called on user login.
         self._properties_updated_handler_called = False
-        login(self.portal, username)
+
         # Imitate a login as the plone.app.testing login method doesn't seem to
         # set these member properties.
         member.setMemberProperties({

--- a/src/Products/PlonePAS/tests/test_memberdatatool.py
+++ b/src/Products/PlonePAS/tests/test_memberdatatool.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 from DateTime import DateTime
 from OFS.Image import Image
+from Products.CMFCore.interfaces import IMemberData
 from Products.PlonePAS.tests import base
 from Products.PlonePAS.tests import dummy
+from Products.PluggableAuthService.interfaces.events import \
+        IPropertiesUpdatedEvent
 from plone.app.testing import TEST_USER_ID as default_user
+import zope.component
 
 
 class TestMemberDataTool(base.TestCase):
@@ -68,3 +72,17 @@ class TestMemberDataTool(base.TestCase):
         self.assertEqual(len(search('bambam.net')), 1)
         self.assertEqual(len(search('bedrock.com')), 2)
         self.assertEqual(len(search('brubble')), 1)
+
+    def testPropertiesUpdatedEvent(self):
+
+        def event_handler(context, event):
+            self._properties_updated_handler_called = True
+
+        gsm = zope.component.getGlobalSiteManager()
+        gsm.registerHandler(event_handler,
+                            (IMemberData, IPropertiesUpdatedEvent))
+
+        self._properties_updated_handler_called = False
+        self.addMember('ez', 'Ez Zy', 'ez@ezmail.net',
+                       ['Member'], '2018-01-01')
+        self.assertTrue(self._properties_updated_handler_called)

--- a/src/Products/PlonePAS/tests/test_memberdatatool.py
+++ b/src/Products/PlonePAS/tests/test_memberdatatool.py
@@ -83,6 +83,41 @@ class TestMemberDataTool(base.TestCase):
                             (IMemberData, IPropertiesUpdatedEvent))
 
         self._properties_updated_handler_called = False
-        self.addMember('ez', 'Ez Zy', 'ez@ezmail.net',
-                       ['Member'], '2018-01-01')
+
+        username = 'ez'
+        roles = ['Member']
+        fullname = 'Ez Zy'
+        email = 'ez@ezmail.net'
+
+        self.membership.addMember(username, 'secret', roles, [])
+        member = self.membership.getMemberById(username)
+
+        self.assertFalse(self._properties_updated_handler_called)
+
+        member.setMemberProperties({
+            'fullname': fullname,
+            'email': email})
+
         self.assertTrue(self._properties_updated_handler_called)
+
+        # Test that notify(PropertiesUpdated) isn't called on user login.
+        self._properties_updated_handler_called = False
+        login(self.portal, username)
+        # Imitate a login as the plone.app.testing login method doesn't seem to
+        # set these member properties.
+        member.setMemberProperties({
+            'login_time': DateTime('2018-02-15'),
+            'last_login_time': DateTime('2018-02-15')})
+
+        self.assertFalse(self._properties_updated_handler_called)
+
+        # Test notify(PropertiesUpdated) isn't called when login_time is
+        # present as we're assuming this should only be changed on login.
+        self._properties_updated_handler_called = False
+        member.setMemberProperties({
+            'login_time': DateTime('2018-02-15'),
+            'fullname': 'Bed Rock'})
+
+        self.assertFalse(self._properties_updated_handler_called)
+        gsm.unregisterHandler(event_handler,
+                              (IMemberData, IPropertiesUpdatedEvent))

--- a/src/Products/PlonePAS/tools/memberdata.py
+++ b/src/Products/PlonePAS/tools/memberdata.py
@@ -17,11 +17,13 @@ from Products.PlonePAS.interfaces.capabilities import IPasswordSetCapability
 from Products.PlonePAS.interfaces.group import IGroupManagement
 from Products.PlonePAS.interfaces.plugins import IUserManagement
 from Products.PlonePAS.interfaces.propertysheets import IMutablePropertySheet
+from Products.PluggableAuthService.events import PropertiesUpdated
 from Products.PluggableAuthService.interfaces.authservice import \
     IPluggableAuthService
 from Products.PluggableAuthService.interfaces.plugins import IPropertiesPlugin
 from Products.PluggableAuthService.interfaces.plugins import \
     IRoleAssignerPlugin
+from zope.event import notify
 from zope.interface import implementer
 
 
@@ -285,6 +287,11 @@ class MemberData(BaseMemberData):
                     break
         if modified:
             self.notifyModified()
+
+        # Trigger PropertiesUpdated event when member properties are updated,
+        # excluding user login events
+        if set(mapping.keys()) != set(('login_time', 'last_login_time')):
+            notify(PropertiesUpdated(self, mapping))
 
     def getProperty(self, id, default=_marker):
         """PAS-specific method to fetch a user's properties. Looks

--- a/src/Products/PlonePAS/tools/memberdata.py
+++ b/src/Products/PlonePAS/tools/memberdata.py
@@ -290,7 +290,7 @@ class MemberData(BaseMemberData):
 
         # Trigger PropertiesUpdated event when member properties are updated,
         # excluding user login events
-        if set(mapping.keys()) != set(('login_time', 'last_login_time')):
+        if not set(mapping.keys()) & set(('login_time', 'last_login_time')):
             notify(PropertiesUpdated(self, mapping))
 
     def getProperty(self, id, default=_marker):


### PR DESCRIPTION
I was hoping someone might have input into whether this is the right place to notify the properties updated event. I'd welcome some feedback / input if anyone has a better place / approach to triggering this event.

I'm also a bit uncertain around the process for a change to be implemented in multiple branches. As the contributor am I encouraged to create out multiple pull requests? If so, I assume it's better to do this after allowing discussion / input on this one?

Cheers