### PR TITLE
Add notify calls for Principal AddedTo / RemovedFrom Group events & changes to PropertiesUpdated events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,12 +10,19 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Notify PropertiesUpdated event when group properties are changed
+  [ezvirtual]
+
+- Notify PrincipalAddedToGroup and PrincipalRemovedFromGroup events
+  [ezvirtual]
+
+- Notify CredentialsUpdated event when password is changed
+  [ezvirtual]
 
 Bug fixes:
 
-- *add item here*
-
+- PropertiesUpdated event - triggered when member properties are changed - now includes user object instead of id
+  [ezvirtual]
 
 5.1.0 (2018-05-01)
 ------------------

--- a/src/Products/PlonePAS/plugins/user.py
+++ b/src/Products/PlonePAS/plugins/user.py
@@ -87,7 +87,7 @@ class UserManager(BasePlugin):
         if self._user_passwords.get(principal_id) is None:
             raise RuntimeError("User does not exist: %s" % principal_id)
         self._user_passwords[principal_id] = AuthEncoding.pw_encrypt(password)
-        notify(CredentialsUpdated(principal_id, password))
+        notify(CredentialsUpdated(self.getUserById(principal_id), password))
 
     # implement interfaces IDeleteCapability, IPasswordSetCapability
 

--- a/src/Products/PlonePAS/plugins/user.py
+++ b/src/Products/PlonePAS/plugins/user.py
@@ -11,9 +11,11 @@ from Products.PlonePAS.interfaces.capabilities import IDeleteCapability
 from Products.PlonePAS.interfaces.capabilities import IPasswordSetCapability
 from Products.PlonePAS.interfaces.plugins import IUserIntrospection
 from Products.PlonePAS.interfaces.plugins import IUserManagement
+from Products.PluggableAuthService.events import CredentialsUpdated
 from Products.PluggableAuthService.plugins.ZODBUserManager \
     import ZODBUserManager as BasePlugin
 from Products.PluggableAuthService.utils import createViewName
+from zope.event import notify
 from zope.interface import implementer
 
 manage_addUserManagerForm = DTMLFile('../zmi/UserManagerForm', globals())
@@ -85,6 +87,7 @@ class UserManager(BasePlugin):
         if self._user_passwords.get(principal_id) is None:
             raise RuntimeError("User does not exist: %s" % principal_id)
         self._user_passwords[principal_id] = AuthEncoding.pw_encrypt(password)
+        notify(CredentialsUpdated(principal_id, password))
 
     # implement interfaces IDeleteCapability, IPasswordSetCapability
 

--- a/src/Products/PlonePAS/tests/test_membershiptool.py
+++ b/src/Products/PlonePAS/tests/test_membershiptool.py
@@ -701,7 +701,7 @@ class TestMembershipTool(base.TestCase):
         self.login(TEST_USER_NAME)
         self.membership.setPassword('guessagain')
         self.assertEqual(len(events_fired), 1)
-        self.assertEqual(events_fired[0].principal, TEST_USER_ID)
+        self.assertEqual(events_fired[0].principal.getId(), TEST_USER_ID)
         self.assertEqual(events_fired[0].password, 'guessagain')
 
         gsm.unregisterHandler(got_credentials_updated_event)

--- a/src/Products/PlonePAS/tools/groupdata.py
+++ b/src/Products/PlonePAS/tools/groupdata.py
@@ -25,8 +25,6 @@ from Products.PlonePAS.utils import CleanupTemp
 from Products.PluggableAuthService.events import PropertiesUpdated
 from Products.PluggableAuthService.PluggableAuthService import \
     _SWALLOWABLE_PLUGIN_EXCEPTIONS
-from Products.PluggableAuthService.events import PrincipalAddedToGroup
-from Products.PluggableAuthService.events import PrincipalRemovedFromGroup
 from Products.PluggableAuthService.interfaces.authservice import \
     IPluggableAuthService
 from ZPublisher.Converters import type_converters
@@ -257,7 +255,6 @@ class GroupData(SimpleItem):
         for mid, manager in managers:
             try:
                 if manager.addPrincipalToGroup(id, self.getId()):
-                    notify(PrincipalAddedToGroup(self.getUserById(id), self))
                     break
             except _SWALLOWABLE_PLUGIN_EXCEPTIONS:
                 pass
@@ -275,8 +272,6 @@ class GroupData(SimpleItem):
         for mid, manager in managers:
             try:
                 if manager.removePrincipalFromGroup(id, self.getId()):
-                    notify(PrincipalRemovedFromGroup(self.getUserById(id),
-                                                     self))
                     break
             except _SWALLOWABLE_PLUGIN_EXCEPTIONS:
                 pass

--- a/src/Products/PlonePAS/tools/groups.py
+++ b/src/Products/PlonePAS/tools/groups.py
@@ -16,8 +16,6 @@ from Products.PlonePAS.permissions import SetGroupOwnership
 from Products.PlonePAS.permissions import ViewGroups
 from Products.PlonePAS.utils import getGroupsForPrincipal
 from Products.PluggableAuthService.events import GroupDeleted
-from Products.PluggableAuthService.events import PrincipalAddedToGroup
-from Products.PluggableAuthService.events import PrincipalRemovedFromGroup
 from Products.PluggableAuthService.PluggableAuthService import \
     _SWALLOWABLE_PLUGIN_EXCEPTIONS
 from Products.PluggableAuthService.interfaces.plugins import \
@@ -200,14 +198,6 @@ class GroupsTool(UniqueObject, SimpleItem):
             raise NotSupported('No plugins allow for group management')
         for mid, manager in managers:
             if manager.addPrincipalToGroup(principal_id, group_id):
-                # As we don't know if principal is user or group at this point
-                # try to get user object first
-                obj = self.acl_users.getUserById(principal_id)
-                # Otherwise get group object
-                if not obj:
-                    obj = self.getGroupById(principal_id)
-                # Notify event
-                notify(PrincipalAddedToGroup(obj, self.getGroupById(group_id)))
                 return True
         return False
 
@@ -219,15 +209,6 @@ class GroupsTool(UniqueObject, SimpleItem):
             raise NotSupported('No plugins allow for group management')
         for mid, manager in managers:
             if manager.removePrincipalFromGroup(principal_id, group_id):
-                # As we don't know if principal is user or group at this point
-                # try to get user object first
-                obj = self.acl_users.getUserById(principal_id)
-                # Otherwise get group object
-                if not obj:
-                    obj = self.getGroupById(principal_id)
-                # Notify event
-                notify(PrincipalRemovedFromGroup(obj,
-                                                 self.getGroupById(group_id)))
                 return True
         return False
 

--- a/src/Products/PlonePAS/tools/memberdata.py
+++ b/src/Products/PlonePAS/tools/memberdata.py
@@ -273,7 +273,7 @@ class MemberData(BaseMemberData):
         # If we got this far, we have a PAS and some property sheets.
         # XXX track values set to defer to default impl
         # property routing?
-        modified = False
+        modified = {}
         for k, v in mapping.items():
             if v is None and not force_empty:
                 continue
@@ -282,16 +282,16 @@ class MemberData(BaseMemberData):
                     continue
                 if IMutablePropertySheet.providedBy(sheet):
                     sheet.setProperty(user, k, v)
-                    modified = True
+                    modified[k] = v
                 else:
                     break
         if modified:
             self.notifyModified()
-
-        # Trigger PropertiesUpdated event when member properties are updated,
-        # excluding user login events
-        if not set(mapping.keys()) & set(('login_time', 'last_login_time')):
-            notify(PropertiesUpdated(self, mapping))
+            # Trigger PropertiesUpdated event when member properties are
+            # updated, excluding user login events
+            if not set(mapping.keys()) & set((
+                    'login_time', 'last_login_time')):
+                notify(PropertiesUpdated(self, modified))
 
     def getProperty(self, id, default=_marker):
         """PAS-specific method to fetch a user's properties. Looks


### PR DESCRIPTION
Hi there,
After implementing the PropertiesUpdated event a while ago I decided that it would be helpful to also implement some other missing events. 

- PropertiesUpdatedEvent - is now called when group properties are updated, event.principal is now the principal object instead of ID as this is also set as event.object in PASEvent
- CredentialsUpdatedEvent is now implemented (Hopefully solves https://github.com/plone/Products.PlonePAS/issues/33)
- PrincipalAddedToGroupEvent and PrincipalRemovedFromGroupEvent are now implemented

We'll need to get the missing events into [Products.PluggableAuthSerivce](https://github.com/zopefoundation/Products.PluggableAuthService) before this code can be tested / merged but I thought I'd create this PR in the hope of getting some input / feedback at this point.