### PR TITLE
WIP: fix existing errors from existing zodb objects in db

### DIFF
--- a/src/Products/PlonePAS/tests/test_membershiptool.py
+++ b/src/Products/PlonePAS/tests/test_membershiptool.py
@@ -20,7 +20,7 @@ from Products.PlonePAS.interfaces.membership import IMembershipTool
 from Products.PlonePAS.plugins.ufactory import PloneUser
 from Products.PlonePAS.testing import PRODUCTS_PLONEPAS_INTEGRATION_TESTING
 from Products.PlonePAS.tests import dummy
-from Products.PlonePAS.tools.memberdata import MemberData
+from Products.PlonePAS.tools.memberdata import MemberDataAdapter
 from Products.PlonePAS.tools.membership import MembershipTool
 from Products.PlonePAS.utils import getGroupsForPrincipal
 from six import BytesIO
@@ -70,7 +70,7 @@ class MembershipToolTest(unittest.TestCase):
         # MemberData object wrapped by PAS (used to be wrapped by member).
         member = self.mt.getMemberById(self.member_id)
         self.assertFalse(member is None)
-        self.assertTrue(isinstance(member, MemberData))
+        self.assertTrue(isinstance(member, MemberDataAdapter))
         self.assertTrue(isinstance(aq_parent(member), PluggableAuthService))
 
     def test_id_clean(self):
@@ -462,7 +462,7 @@ class TestMembershipTool(unittest.TestCase):
     def testGetMemberByIdIsWrapped(self):
         member = self.membership.getMemberById(TEST_USER_ID)
         self.assertNotEqual(member, None)
-        self.assertEqual(member.__class__.__name__, 'MemberData')
+        self.assertEqual(member.__class__.__name__, 'MemberDataAdapter')
         self.assertEqual(aq_parent(member).__class__.__name__,
                          'PluggableAuthService')
 
@@ -473,7 +473,7 @@ class TestMembershipTool(unittest.TestCase):
     def testGetAuthenticatedMemberIsWrapped(self):
         member = self.membership.getAuthenticatedMember()
         self.assertEqual(member.getUserName(), TEST_USER_NAME)
-        self.assertEqual(member.__class__.__name__, 'MemberData')
+        self.assertEqual(member.__class__.__name__, 'MemberDataAdapter')
         self.assertEqual(aq_parent(member).__class__.__name__,
                          'PluggableAuthService')
 
@@ -486,7 +486,7 @@ class TestMembershipTool(unittest.TestCase):
         # Also see http://dev.plone.org/plone/ticket/1851
         logout()
         member = self.membership.getAuthenticatedMember()
-        self.assertNotEqual(member.__class__.__name__, 'MemberData')
+        self.assertNotEqual(member.__class__.__name__, 'MemberDataAdapter')
         self.assertEqual(member.__class__.__name__, 'SpecialUser')
 
     def testIsAnonymousUser(self):
@@ -499,7 +499,7 @@ class TestMembershipTool(unittest.TestCase):
         self.assertTrue(hasattr(user, 'aq_base'))
         user = aq_base(user)
         user = self.membership.wrapUser(user)
-        self.assertEqual(user.__class__.__name__, 'MemberData')
+        self.assertEqual(user.__class__.__name__, 'MemberDataAdapter')
         self.assertEqual(aq_parent(user).__class__.__name__,
                          'PluggableAuthService')
 
@@ -507,7 +507,7 @@ class TestMembershipTool(unittest.TestCase):
         user = self.portal.acl_users.getUserById(TEST_USER_ID)
         self.assertTrue(hasattr(user, 'aq_base'))
         user = self.membership.wrapUser(user)
-        self.assertEqual(user.__class__.__name__, 'MemberData')
+        self.assertEqual(user.__class__.__name__, 'MemberDataAdapter')
         self.assertEqual(aq_parent(user).__class__.__name__,
                          'PluggableAuthService')
 
@@ -524,7 +524,7 @@ class TestMembershipTool(unittest.TestCase):
     def testWrapUserWrapsAnonymous(self):
         self.assertFalse(hasattr(nobody, 'aq_base'))
         user = self.membership.wrapUser(nobody, wrap_anon=1)
-        self.assertEqual(user.__class__.__name__, 'MemberData')
+        self.assertEqual(user.__class__.__name__, 'MemberDataAdapter')
         self.assertEqual(aq_parent(user).__class__.__name__,
                          'PluggableAuthService')
 

--- a/src/Products/PlonePAS/tools/groupdata.py
+++ b/src/Products/PlonePAS/tools/groupdata.py
@@ -20,7 +20,7 @@ from Products.PlonePAS.interfaces.group import IGroupData
 from Products.PlonePAS.interfaces.group import IGroupDataTool
 from Products.PlonePAS.interfaces.group import IGroupManagement
 from Products.PlonePAS.interfaces.propertysheets import IMutablePropertySheet
-from Products.PlonePAS.tools.memberdata import MemberData
+from Products.PlonePAS.tools.memberdata import MemberDataAdapter
 from Products.PlonePAS.utils import CleanupTemp
 from Products.PluggableAuthService.PluggableAuthService import \
     _SWALLOWABLE_PLUGIN_EXCEPTIONS
@@ -516,14 +516,14 @@ class GroupData(SimpleItem):
         return 0
 
     if six.PY3:
-        canAddToGroup = MemberData.canAddToGroup
-        canRemoveFromGroup = MemberData.canRemoveFromGroup
-        canAssignRole = MemberData.canAssignRole
+        canAddToGroup = MemberDataAdapter.canAddToGroup
+        canRemoveFromGroup = MemberDataAdapter.canRemoveFromGroup
+        canAssignRole = MemberDataAdapter.canAssignRole
     else:
         # in PY2 this is a unbound method
-        canAddToGroup = MemberData.canAddToGroup.__func__
-        canRemoveFromGroup = MemberData.canRemoveFromGroup.__func__
-        canAssignRole = MemberData.canAssignRole.__func__
+        canAddToGroup = MemberDataAdapter.canAddToGroup.__func__
+        canRemoveFromGroup = MemberDataAdapter.canRemoveFromGroup.__func__
+        canAssignRole = MemberDataAdapter.canAssignRole.__func__
 
     # plugin getters
 

--- a/src/Products/PlonePAS/tools/memberdata.py
+++ b/src/Products/PlonePAS/tools/memberdata.py
@@ -6,6 +6,7 @@ from Products.BTreeFolder2.BTreeFolder2 import BTreeFolder2
 from Products.CMFCore.interfaces import IMember
 from Products.CMFCore.MemberDataTool import _marker
 from Products.CMFCore.MemberDataTool import MemberAdapter as BaseMemberAdapter
+from Products.CMFCore.MemberDataTool import MemberData as BaseMemberData
 from Products.CMFCore.MemberDataTool import MemberDataTool as BaseTool
 from Products.CMFCore.permissions import ManagePortal
 from Products.CMFCore.utils import getToolByName
@@ -224,8 +225,17 @@ class MemberDataTool(BaseTool):
 InitializeClass(MemberDataTool)
 
 
+# b/w compat import for persistent data
+MemberData = BaseMemberData
+
+
 @implementer(IManageCapabilities, IMember)
-class MemberData(BaseMemberAdapter):
+class MemberDataAdapter(BaseMemberAdapter):
+    '''
+    Make sure `MemberDataAdapter` name does not match
+    previous persistent class `MemberData` for existing
+    objects stored in zodb
+    '''
 
     security = ClassSecurityInfo()
 


### PR DESCRIPTION
Anyone have opinions on this? @plone/framework-team

I'm not sure this is correct but I have ZODB objects referencing the `MemberData` class and it seems we re-purposed it to be the adapter implementation.

If you're upgrading, this breaks existing objects.