### PR TITLE
log exception in pas.logout()

### DIFF
--- a/news/50.bugfix
+++ b/news/50.bugfix
@@ -1,0 +1,2 @@
+Log exception from PAS logout() instead of swallowing them
+[ajung]

--- a/src/Products/PlonePAS/tools/membership.py
+++ b/src/Products/PlonePAS/tools/membership.py
@@ -705,10 +705,8 @@ class MembershipTool(BaseTool):
             pas = getToolByName(self, 'acl_users')
             try:
                 pas.logout(REQUEST)
-            except:
-                # XXX Bare except copied from logout.cpy. This should be
-                # changed in the next Plone release.
-                pass
+            except Exception as e:
+                logger.error('Error in PAS logout()', exc_info=True)
 
             # Expire the skin cookie if it is not configured to persist
             st = getToolByName(self, "portal_skins")


### PR DESCRIPTION
This PR turned a bare try-except around `pas.logout`  into a logger warning.