### PR TITLE
Use MemberData adapter

### DIFF
--- a/news/52.bugfix
+++ b/news/52.bugfix
@@ -1,0 +1,3 @@
+Create the MemberData object from an adapter instead of directly instantiating it, as intended in Products.CMFCore.MemberDataTool.
+This allows for better extensibility.
+[thet]

--- a/src/Products/PlonePAS/configure.zcml
+++ b/src/Products/PlonePAS/configure.zcml
@@ -6,6 +6,7 @@
     xmlns:i18n="http://namespaces.zope.org/i18n">
 
   <include package=".browser" />
+  <include package=".tools" />
   <include file="profiles.zcml" />
   <include file="exportimport.zcml" />
 

--- a/src/Products/PlonePAS/interfaces/memberdata.py
+++ b/src/Products/PlonePAS/interfaces/memberdata.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from Products.CMFCore import interfaces
+
+
+class IMemberDataTool(interfaces.IMemberDataTool):
+    """More specific PlonePAS MemberDataTool interface.
+    """
+
+
+__all__ = (IMemberDataTool,)

--- a/src/Products/PlonePAS/tests/test_memberdatatool.py
+++ b/src/Products/PlonePAS/tests/test_memberdatatool.py
@@ -4,6 +4,8 @@ from OFS.Image import Image
 from plone.app.testing import TEST_USER_ID as default_user
 from Products.PlonePAS.tests import dummy
 from Products.PlonePAS.testing import PRODUCTS_PLONEPAS_INTEGRATION_TESTING
+from zope.component import getMultiAdapter
+from Products.CMFCore.interfaces import IMember
 
 import unittest
 
@@ -73,3 +75,16 @@ class TestMemberDataTool(unittest.TestCase):
         self.assertEqual(len(search('bambam.net')), 1)
         self.assertEqual(len(search('bedrock.com')), 2)
         self.assertEqual(len(search('brubble')), 1)
+
+    def testMemberDataAdapter(self):
+        """Test, if the PlonePAS MemberData adapter is used instead of the
+        default one from Products.CMFCore.MemberDataTool
+        """
+        from Products.PlonePAS.tools.memberdata import MemberData
+        member = self.membership.getMemberById('fred')
+
+        adapter = getMultiAdapter((member, self.memberdata), IMember)
+        self.assertEqual(adapter.__class__, MemberData)
+
+        wrapped_user = self.memberdata.wrapUser(member)
+        self.assertEqual(wrapped_user.__class__, MemberData)

--- a/src/Products/PlonePAS/tools/configure.zcml
+++ b/src/Products/PlonePAS/tools/configure.zcml
@@ -1,0 +1,8 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <adapter
+      provides="Products.CMFCore.interfaces.IMember"
+      factory=".memberdata.MemberData"
+      />
+
+</configure>

--- a/src/Products/PlonePAS/tools/memberdata.py
+++ b/src/Products/PlonePAS/tools/memberdata.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from AccessControl import ClassSecurityInfo
+from AccessControl.interfaces import IUser
 from AccessControl.requestmethod import postonly
 from AccessControl.class_init import InitializeClass
 from Products.BTreeFolder2.BTreeFolder2 import BTreeFolder2
@@ -15,6 +16,7 @@ from Products.PlonePAS.interfaces.capabilities import IGroupCapability
 from Products.PlonePAS.interfaces.capabilities import IManageCapabilities
 from Products.PlonePAS.interfaces.capabilities import IPasswordSetCapability
 from Products.PlonePAS.interfaces.group import IGroupManagement
+from Products.PlonePAS.interfaces.memberdata import IMemberDataTool
 from Products.PlonePAS.interfaces.plugins import IUserManagement
 from Products.PlonePAS.interfaces.propertysheets import IMutablePropertySheet
 from Products.PluggableAuthService.interfaces.authservice import \
@@ -22,11 +24,13 @@ from Products.PluggableAuthService.interfaces.authservice import \
 from Products.PluggableAuthService.interfaces.plugins import IPropertiesPlugin
 from Products.PluggableAuthService.interfaces.plugins import \
     IRoleAssignerPlugin
+from zope.component import adapter
 from zope.interface import implementer
 
 import six
 
 
+@implementer(IMemberDataTool)
 class MemberDataTool(BaseTool):
     """PAS-specific implementation of memberdata tool.
     """
@@ -185,13 +189,6 @@ class MemberDataTool(BaseTool):
             pass
         return False
 
-    def wrapUser(self, u):
-        '''
-        If possible, returns the Member object that corresponds
-        to the given User object.
-        '''
-        return MemberData(u, self)
-
     @postonly
     def deleteMemberData(self, member_id, REQUEST=None):
         """ Delete member data of specified member.
@@ -221,10 +218,12 @@ class MemberDataTool(BaseTool):
     def _getPlugins(self):
         return self.acl_users.plugins
 
+
 InitializeClass(MemberDataTool)
 
 
 @implementer(IManageCapabilities, IMember)
+@adapter(IUser, IMemberDataTool)
 class MemberData(BaseMemberAdapter):
 
     security = ClassSecurityInfo()


### PR DESCRIPTION
Create the MemberData object from an adapter instead of directly instantiating it, as intended in Products.CMFCore.MemberDataTool.
This allows for better extensibility.

This PR uses the wrapUser method from it's superclass, which itself queries an adapter since:
https://github.com/zopefoundation/Products.CMFCore/commit/a876001ec24c4ac7b3a3ca0db3114ceb58d77e5f

/cc @ale-rt 