### PR TITLE
rm deprection message: AccessControl.User has moved to AccessControl.users

### DIFF
--- a/news/59.bugfix
+++ b/news/59.bugfix
@@ -1,0 +1,2 @@
+Fixes deprection message: `AccessControl.User has moved to AccessControl.users`.
+[jensens]

--- a/src/Products/PlonePAS/tools/groups.py
+++ b/src/Products/PlonePAS/tools/groups.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from AccessControl import ClassSecurityInfo
-from AccessControl.User import nobody
+from AccessControl.users import nobody
 from AccessControl.requestmethod import postonly
 from Acquisition import aq_base
 from Acquisition import aq_inner


### PR DESCRIPTION
fix 
```
DeprecationWarning: nobody is deprecated. The functionality of AccessControl.User has moved to AccessControl.users. Please import from there. This backward compatibility shim will be removed in AccessControl version 6.
  from AccessControl.User import nobody
```