### PR TITLE
Fixed tests for cookie auth to also work with zope.interface 5.3.0. [master]

### DIFF
--- a/news/237.bugfix
+++ b/news/237.bugfix
@@ -1,0 +1,4 @@
+Fixed tests for cookie auth to also work with `zope.interface` 5.3.0.
+This uses simpler representations for interfaces.
+Tests now pass with earlier and later versions.
+[maurits]

--- a/src/Products/PlonePAS/tests/cookie_auth.rst
+++ b/src/Products/PlonePAS/tests/cookie_auth.rst
@@ -53,13 +53,16 @@ Make sure cookie plugin is installed and activated.
   ...       pass
 
   >>> for active, iface in actives:
-  ...     print(iface)
+  ...     print(iface.__name__)
   ...     for id, plugin in active:
   ...         if id == 'credentials_cookie_auth':
   ...            print(True)
-  <...IExtraction...>...True
-  <...IChallenge...>...True
-  <...ICredentialsUpdate...>...<...ICredentialsReset...>
+  IExtractionPlugin
+  True
+  IChallengePlugin
+  True
+  ICredentialsUpdatePlugin
+  ICredentialsResetPlugin
 
 User in parent folder
 ---------------------


### PR DESCRIPTION
This uses simpler representations for interfaces.
Tests now pass with earlier and later versions.

Original error from [Jenkins](https://jenkins.plone.org/job/pull-request-5.2-3.6/1938/testReport/junit/Products.PlonePAS/tests/cookie_auth_rst/):

```
File "/home/jenkins/.buildout/eggs/cp36m/Products.PlonePAS-6.0.7-py3.6.egg/Products/PlonePAS/tests/cookie_auth.rst", line 55, in cookie_auth.rst
Failed example:
    for active, iface in actives:
        print(iface)
        for id, plugin in active:
            if id == 'credentials_cookie_auth':
               print(True)
Expected:
    <...IExtraction...>...True
    <...IChallenge...>...True
    <...ICredentialsUpdate...>...<...ICredentialsReset...>
Got:
    Products.PluggableAuthService.interfaces.plugins.IExtractionPlugin
    True
    Products.PluggableAuthService.interfaces.plugins.IChallengePlugin
    True
    Products.PluggableAuthService.interfaces.plugins.ICredentialsUpdatePlugin
    Products.PluggableAuthService.interfaces.plugins.ICredentialsResetPlugin
```

The fix is to print `iface.__name__`, which looks the same in all versions.