### PR TITLE
fix(setup): Zope root cookie auth and login form

### DIFF
--- a/news/65.bugfix
+++ b/news/65.bugfix
@@ -1,0 +1,2 @@
+Fix broken Zope root `/acl_users` cookie plugin on `PlonePAS` install.
+[rpatterson]

--- a/src/Products/PlonePAS/tests/test_setup.py
+++ b/src/Products/PlonePAS/tests/test_setup.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
+from plone.app import testing as pa_testing
 from plone.testing import zope
+from zope.component import hooks
 from Products.PlonePAS import testing
 from Products.PluggableAuthService.interfaces import plugins as plugins_ifaces
+from Products.PluggableAuthService.plugins import CookieAuthHelper
 from Products.PluggableAuthService.plugins import HTTPBasicAuthHelper
 
+import transaction
 import unittest
+import urllib.parse
 
 
 class PortalSetupTest(unittest.TestCase):
@@ -52,4 +57,78 @@ class PortalSetupTest(unittest.TestCase):
             browser.headers["Status"].lower(),
             "401 unauthorized",
             "Wrong Zope root `/acl_users` default challenge response status",
+        )
+
+    def test_zope_root_cookie_login(self):
+        """
+        The Zope root `/acl_users` cookie login works.
+        """
+        # Make the cookie plugin the default auth challenge
+        self.assertIn(
+            "credentials_cookie_auth",
+            self.root_acl_users.objectIds(),
+            "Cookie auth plugin missing from Zope root `/acl_users`",
+        )
+        cookie_plugin = self.root_acl_users.credentials_cookie_auth
+        self.assertIs(
+            type(cookie_plugin.aq_base),
+            CookieAuthHelper.CookieAuthHelper,
+            "Wrong Zope root `/acl_users` cookie auth plugin type",
+        )
+        self.root_acl_users.plugins.activatePlugin(
+            plugins_ifaces.IChallengePlugin,
+            cookie_plugin.id,
+        )
+        self.root_acl_users.plugins.movePluginsTop(
+            plugins_ifaces.IChallengePlugin,
+            [cookie_plugin.id],
+        )
+        transaction.commit()
+        challenge_plugins = self.root_acl_users.plugins.listPlugins(
+            plugins_ifaces.IChallengePlugin,
+        )
+        _, default_challenge_plugin = challenge_plugins[0]
+        self.assertEqual(
+            "/".join(default_challenge_plugin.getPhysicalPath()),
+            "/".join(cookie_plugin.getPhysicalPath()),
+            "Wrong Zope root `/acl_users` default challenge plugin",
+        )
+
+        # Check the challenge response in the actual browser
+        browser = zope.Browser(self.app)
+        browser.open(self.app.absolute_url() + "/manage_main")
+        self.assertEqual(
+            browser.headers["Status"].lower(),
+            "200 ok",
+            "Wrong Zope root `/acl_users` cookie challenge response status",
+        )
+        login_form_url = urllib.parse.urlsplit(browser.url)
+        self.assertEqual(
+            login_form_url._replace(query="").geturl(),
+            cookie_plugin.absolute_url() + "/login_form",
+            "Wrong Zope root `/acl_users` cookie challenge redirect",
+        )
+
+        # Workaround the fact that the `zope.component` site is still the Plone portal
+        # when the test browser handles requests.
+        hooks.setSite(None)
+        zope.login(self.root_acl_users, pa_testing.SITE_OWNER_NAME)
+        self.app.REQUEST.form["__ac_name"] = pa_testing.SITE_OWNER_NAME
+        self.app.REQUEST.form["__ac_password"] = pa_testing.TEST_USER_PASSWORD
+        cookie_plugin.login()
+
+        # Submit the login form in the browser
+        login_form = browser.getForm()
+        login_form.getControl(name="__ac_name").value = pa_testing.SITE_OWNER_NAME
+        login_form.getControl(name="__ac_password").value = pa_testing.TEST_USER_PASSWORD
+        login_form.controls[-1].click()
+        self.assertEqual(
+            browser.headers["Status"].lower(),
+            "200 ok",
+            "Wrong Zope root `/acl_users` cookie login response status",
+        )
+        self.assertEqual(
+            browser.url,
+            self.app.absolute_url() + "/manage_main",
+            "Wrong Zope root `/acl_users` cookie login redirect",
         )

--- a/src/Products/PlonePAS/tests/test_setup.py
+++ b/src/Products/PlonePAS/tests/test_setup.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from plone.testing import zope
+from Products.PlonePAS import testing
+from Products.PluggableAuthService.interfaces import plugins as plugins_ifaces
+from Products.PluggableAuthService.plugins import HTTPBasicAuthHelper
+
+import unittest
+
+
+class PortalSetupTest(unittest.TestCase):
+
+    layer = testing.PRODUCTS_PLONEPAS_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        """
+        Set up convenience references to test fixture from the layer.
+        """
+        self.app = self.layer["app"]
+        self.root_acl_users = self.app.acl_users
+
+    def test_zope_root_default_challenge(self):
+        """
+        The Zope root `/acl_users` default challenge plugin works.
+        """
+        # Check the Zope root PAS plugin configuration
+        self.assertIn(
+            "credentials_basic_auth",
+            self.root_acl_users.objectIds(),
+            "Basic auth plugin missing from Zope root `/acl_users`",
+        )
+        basic_plugin = self.root_acl_users.credentials_basic_auth
+        self.assertIsInstance(
+            basic_plugin,
+            HTTPBasicAuthHelper.HTTPBasicAuthHelper,
+            "Wrong Zope root `/acl_users` basic auth plugin type",
+        )
+        challenge_plugins = self.root_acl_users.plugins.listPlugins(
+            plugins_ifaces.IChallengePlugin,
+        )
+        _, default_challenge_plugin = challenge_plugins[0]
+        self.assertEqual(
+            "/".join(default_challenge_plugin.getPhysicalPath()),
+            "/".join(basic_plugin.getPhysicalPath()),
+            "Wrong Zope root `/acl_users` default challenge plugin",
+        )
+
+        # Check the challenge response in the actual browser
+        browser = zope.Browser(self.app)
+        browser.raiseHttpErrors = False
+        browser.open(self.app.absolute_url() + "/manage_main")
+        self.assertEqual(
+            browser.headers["Status"].lower(),
+            "401 unauthorized",
+            "Wrong Zope root `/acl_users` default challenge response status",
+        )


### PR DESCRIPTION
The GenericSetup "various" import step that originally installs PAS into a Plone portal
also migrates the Zope root `/acl_users`.  Probably an accident over time, but it
results in a cookie auth plugin that doesn't work outside of the Plone portal:

    2021-12-27 11:12:02,243 ERROR   [Zope.SiteErrorLog:22][waitress-0] ComponentLookupError: http://localhost:49080/api/acl_users/credentials_cookie_auth/login
    Traceback (innermost last):
      Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
      Module ZPublisher.WSGIPublisher, line 372, in publish_module
      Module ZPublisher.WSGIPublisher, line 266, in publish
      Module ZPublisher.mapply, line 85, in mapply
      Module ZPublisher.WSGIPublisher, line 63, in call_object
      Module Products.PlonePAS.plugins.cookie_handler, line 106, in login
      Module Products.PluggableAuthService.PluggableAuthService, line 1153, in updateCredentials
      Module Products.PlonePAS.plugins.cookie_handler, line 74, in updateCredentials
      Module zope.component._api, line 165, in getUtility
    zope.interface.interfaces.ComponentLookupError: (<InterfaceClass plone.registry.interfaces.IRegistry>, '')

This import step also removes the `login_form` template which breaks the challenge
response.

Add an interface check to decide whether to install Plone's `ExtendedCookieAuthHelper`
or PAS's vanilla `CookieAuthHelper`.