### PR TITLE
Translate error message, simplify error handling

### DIFF
--- a/news/75.bugfix
+++ b/news/75.bugfix
@@ -1,0 +1,1 @@
+Translate error message, simplify error handling. [tschorr]

--- a/src/Products/PlonePAS/plugins/passwordpolicy.py
+++ b/src/Products/PlonePAS/plugins/passwordpolicy.py
@@ -7,6 +7,7 @@ from AccessControl.class_init import InitializeClass
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from Products.PluggableAuthService.interfaces.plugins import IValidationPlugin
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
+from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.i18nmessageid import MessageFactory
 from zope.interface import implementer
@@ -66,7 +67,8 @@ class PasswordPolicyPlugin(BasePlugin):
                         _(
                             "Your password must contain at least ${min_chars} characters.",
                             mapping={"min_chars": str(self.min_chars)},
-                        )
+                        ),
+                        context=getRequest(),
                     ),
                 }
             ]

--- a/src/Products/PlonePAS/plugins/passwordpolicy.py
+++ b/src/Products/PlonePAS/plugins/passwordpolicy.py
@@ -62,10 +62,12 @@ class PasswordPolicyPlugin(BasePlugin):
             return [
                 {
                     "id": "password",
-                    "error": translate(_(
-                        "Your password must contain at least ${min_chars} characters.",
-                        mapping={"min_chars": str(self.min_chars)},
-                    )),
+                    "error": translate(
+                        _(
+                            "Your password must contain at least ${min_chars} characters.",
+                            mapping={"min_chars": str(self.min_chars)},
+                        )
+                    ),
                 }
             ]
         else:

--- a/src/Products/PlonePAS/plugins/passwordpolicy.py
+++ b/src/Products/PlonePAS/plugins/passwordpolicy.py
@@ -7,6 +7,7 @@ from AccessControl.class_init import InitializeClass
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from Products.PluggableAuthService.interfaces.plugins import IValidationPlugin
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
+from zope.i18n import translate
 from zope.i18nmessageid import MessageFactory
 from zope.interface import implementer
 
@@ -57,24 +58,14 @@ class PasswordPolicyPlugin(BasePlugin):
         password = set_info.get("password", None)
         if password is None:
             return []
-        elif password == "":
-            return [
-                {
-                    "id": "password",
-                    "error": _(
-                        "Minimum ${min_chars} characters.",
-                        mapping={"min_chars": str(self.min_chars)},
-                    ),
-                }
-            ]
         elif len(password) < self.min_chars:
             return [
                 {
                     "id": "password",
-                    "error": _(
+                    "error": translate(_(
                         "Your password must contain at least ${min_chars} characters.",
                         mapping={"min_chars": str(self.min_chars)},
-                    ),
+                    )),
                 }
             ]
         else:


### PR DESCRIPTION
[RegistrationTool.pasValidation](https://github.com/plone/Products.CMFPlone/blob/86a129f828ca3de62dd8d01639735dccfcb93243/Products/CMFPlone/RegistrationTool.py#L220) expects *translated* error messages, however the password policy plugin doesn't translate the minimum length error message. Also simplify the error handling.

This is a follow up to https://github.com/plone/plone.restapi/pull/1630 - the idea is to use the correctly rendered error message for display in Volto's `PasswordReset.jsx` (without this fix, the actual value of `min_chars` will not be rendered).