### PR TITLE
Protect the pas_search view

### DIFF
--- a/news/94.bugfix.rst
+++ b/news/94.bugfix.rst
@@ -1,0 +1,1 @@
+Protect the pas_search view with the ``cmf.ListPortalMembers`` permission [ale-rt]

--- a/src/Products/PlonePAS/browser/configure.zcml
+++ b/src/Products/PlonePAS/browser/configure.zcml
@@ -31,7 +31,7 @@
       for="*"
       class=".search.PASSearchView"
       allowed_interface="Products.PlonePAS.interfaces.browser.IPASSearchView"
-      permission="zope2.View"
+      permission="cmf.ListPortalMembers"
       />
 
 </configure>


### PR DESCRIPTION
Protect the pas_search view with the `cmf.ListPortalMembers` permission

**Note**: A different fix would be to remove the `allowed_interface`.

That would make the view methods unavailable TTW. 
I think the intended consumer of the methods are Python code and page templates.