### PR TITLE
Remove 14 unused GRUF PAS patches, deprecate getGroups

### DIFF
--- a/news/4.breaking
+++ b/news/4.breaking
@@ -1,0 +1,7 @@
+Remove 15 unused GRUF backward-compatibility methods from PAS monkey-patches:
+``_doChangeGroup``, ``_doChangeUser``, ``_doDelGroups``, ``_doDelUsers``,
+``_updateGroup``, ``addRole``, ``getAllLocalRoles``, ``getGroupByName``,
+``getGroupIds``, ``getGroupNames``, ``getGroups``, ``getPureUsers``,
+``getUserIds``, ``userFolderEditGroup``, ``userFolderDelGroups``.
+These methods had zero callers in the Plone 6 codebase.
+See `Products.PlonePAS#4 <https://github.com/plone/Products.PlonePAS/issues/4>`_.

--- a/news/4.breaking
+++ b/news/4.breaking
@@ -1,7 +1,8 @@
-Remove 15 unused GRUF backward-compatibility methods from PAS monkey-patches:
+Remove 14 unused GRUF backward-compatibility methods from PAS monkey-patches:
 ``_doChangeGroup``, ``_doChangeUser``, ``_doDelGroups``, ``_doDelUsers``,
 ``_updateGroup``, ``addRole``, ``getAllLocalRoles``, ``getGroupByName``,
-``getGroupIds``, ``getGroupNames``, ``getGroups``, ``getPureUsers``,
+``getGroupIds``, ``getGroupNames``, ``getPureUsers``,
 ``getUserIds``, ``userFolderEditGroup``, ``userFolderDelGroups``.
-These methods had zero callers in the Plone 6 codebase.
+Deprecate ``getGroups`` (use ``portal_groups.listGroups()`` instead).
+These methods had zero direct callers in the Plone 6 codebase.
 See `Products.PlonePAS#4 <https://github.com/plone/Products.PlonePAS/issues/4>`_.

--- a/src/Products/PlonePAS/pas.py
+++ b/src/Products/PlonePAS/pas.py
@@ -160,6 +160,11 @@ def _doAddGroup(self, id, roles, groups=None, **kw):
     return gtool.addGroup(id, roles, groups, **kw)
 
 
+def getGroups(self):
+    gtool = getToolByName(self, "portal_groups")
+    return gtool.listGroups()
+
+
 def getGroup(self, group_id):
     """Like getGroupById in groups tool, but doesn't wrap."""
     group = None
@@ -440,6 +445,14 @@ def patch_pas():
         "credentialsChanged",
         credentialsChanged,
         add=True,
+        roles=PermissionRole(ManageUsers, ("Manager",)),
+    )
+    wrap_method(
+        PluggableAuthService,
+        "getGroups",
+        getGroups,
+        add=True,
+        deprecated="GRUF compatibility method, use portal_groups.listGroups() instead.",
         roles=PermissionRole(ManageUsers, ("Manager",)),
     )
     wrap_method(

--- a/src/Products/PlonePAS/pas.py
+++ b/src/Products/PlonePAS/pas.py
@@ -2,7 +2,6 @@
 from AccessControl import getSecurityManager
 from AccessControl import Unauthorized
 from AccessControl.PermissionRole import PermissionRole
-from AccessControl.Permissions import change_permissions
 from AccessControl.Permissions import manage_properties
 from AccessControl.Permissions import manage_users as ManageUsers
 from AccessControl.requestmethod import postonly
@@ -82,7 +81,7 @@ def _userSetGroups(pas, user_id, groupnames):
 
 
 #################################
-# pas folder monkeys - standard zope user folder api or GRUF
+# pas folder monkeys - standard zope user folder api
 
 
 def _doAddUser(self, login, password, roles, domains, groups=None, **kw):
@@ -92,15 +91,6 @@ def _doAddUser(self, login, password, roles, domains, groups=None, **kw):
     if groups is not None:
         _userSetGroups(self, login, groups)
     return retval
-
-
-def _doDelUsers(self, names, REQUEST=None):
-    """
-    Delete users given by a list of user ids.
-    Has no return value, like the original (GRUF).
-    """
-    for name in names:
-        self._doDelUser(name)
 
 
 def _doDelUser(self, id):
@@ -159,54 +149,15 @@ def userFolderAddUser(
         _userSetGroups(self, login, groups)
 
 
+def userFolderDelUsers(self, names, REQUEST=None):
+    """Delete users given by a list of user ids."""
+    for name in names:
+        self._doDelUser(name)
+
+
 def _doAddGroup(self, id, roles, groups=None, **kw):
     gtool = getToolByName(self, "portal_groups")
     return gtool.addGroup(id, roles, groups, **kw)
-
-
-# for prefs_group_manage compatibility. really should be using tool.
-def _doDelGroups(self, names, REQUEST=None):
-    gtool = getToolByName(self, "portal_groups")
-    for group_id in names:
-        gtool.removeGroup(group_id)
-
-
-def _doChangeGroup(self, principal_id, roles, groups=None, REQUEST=None, **kw):
-    """
-    Given a group's id, change its roles, domains, if respective
-    plugins for such exist. Domains are currently ignored.
-
-    See also _doChangeUser
-    """
-    gtool = getToolByName(self, "portal_groups")
-    gtool.editGroup(principal_id, roles, groups, **kw)
-    return True
-
-
-def _updateGroup(self, principal_id, roles=None, groups=None, **kw):
-    """
-    Given a group's id, change its roles, groups, if respective
-    plugins for such exist. Domains are ignored.
-
-    This is not an alias to _doChangeGroup because its params are different
-    (slightly).
-    """
-    return self._doChangeGroup(principal_id, roles, groups, **kw)
-
-
-def getGroups(self):
-    gtool = getToolByName(self, "portal_groups")
-    return gtool.listGroups()
-
-
-def getGroupNames(self):
-    gtool = getToolByName(self, "portal_groups")
-    return gtool.getGroupIds()
-
-
-def getGroupIds(self):
-    gtool = getToolByName(self, "portal_groups")
-    return gtool.getGroupIds()
 
 
 def getGroup(self, group_id):
@@ -221,13 +172,6 @@ def getGroup(self, group_id):
         if group is not None:
             break
     return group
-
-
-def getGroupByName(self, name, default=None):
-    ret = self.getGroup(name)
-    if ret is None:
-        return default
-    return ret
 
 
 def getGroupById(self, id, default=None):
@@ -369,25 +313,6 @@ def _delOb(self, id):
     Folder._delOb(self, id)
 
 
-def addRole(self, role):
-    plugins = self._getOb("plugins")
-    roles = plugins.listPlugins(IRoleAssignerPlugin)
-
-    for plugin_id, plugin in roles:
-        try:
-            plugin.addRole(role)
-            break
-        except _SWALLOWABLE_PLUGIN_EXCEPTIONS:
-            pass
-
-
-def getAllLocalRoles(self, context):
-    # Perform security check on destination object
-    if not getSecurityManager().checkPermission(change_permissions, context):
-        raise Unauthorized(name="getAllLocalRoles")
-    return self._getAllLocalRoles(context)
-
-
 def _getAllLocalRoles(self, context):
     plugins = self._getOb("plugins")
     lrmanagers = plugins.listPlugins(ILocalRolesPlugin)
@@ -445,32 +370,6 @@ def authenticate(self, name, password, request):
     return self._findUser(plugins, user_id, name, request)
 
 
-def getUserIds(self):
-    """method was used at GRUF and is here for bbb. Not good for many users!
-    DEPRECATED
-    """
-    plugins = self.plugins
-
-    try:
-        introspectors = plugins.listPlugins(IUserIntrospection)
-    except _SWALLOWABLE_PLUGIN_EXCEPTIONS:
-        logger.info("PluggableAuthService: Plugin listing error", exc_info=1)
-        introspectors = ()
-
-    results = []
-    for introspector_id, introspector in introspectors:
-        try:
-            results.extend(introspector.getUserIds())
-        except _SWALLOWABLE_PLUGIN_EXCEPTIONS:
-            logger.info(
-                "PluggableAuthService: UserIntrospection %s error",
-                introspector_id,
-                exc_info=1,
-            )
-
-    return results
-
-
 def getUserNames(self):
     """method was used at GRUF and is here for bbb. Not good for many users!
     DEPRECATED
@@ -508,30 +407,12 @@ def patch_pas():
     )
     wrap_method(PluggableAuthService, "_doAddGroup", _doAddGroup, add=True)
     wrap_method(PluggableAuthService, "_doAddUser", _doAddUser)
-    wrap_method(PluggableAuthService, "_doChangeGroup", _doChangeGroup, add=True)
-    wrap_method(PluggableAuthService, "_doChangeUser", _doChangeUser, add=True)
-    wrap_method(PluggableAuthService, "_doDelGroups", _doDelGroups, add=True)
     wrap_method(PluggableAuthService, "_doDelUser", _doDelUser, add=True)
-    wrap_method(
-        PluggableAuthService,
-        "_doDelUsers",
-        _doDelUsers,
-        add=True,
-        roles=PermissionRole(ManageUsers, ("Manager",)),
-    )
     wrap_method(
         PluggableAuthService,
         "_getLocalRolesForDisplay",
         _getLocalRolesForDisplay,
         add=True,
-    )
-    wrap_method(PluggableAuthService, "_updateGroup", _updateGroup, add=True)
-    wrap_method(
-        PluggableAuthService,
-        "addRole",
-        addRole,
-        add=True,
-        roles=PermissionRole(ManageUsers, ("Manager",)),
     )
     wrap_method(
         PluggableAuthService,
@@ -563,12 +444,6 @@ def patch_pas():
     )
     wrap_method(
         PluggableAuthService,
-        "getAllLocalRoles",
-        getAllLocalRoles,
-        add=True,
-    )
-    wrap_method(
-        PluggableAuthService,
         "getGroup",
         getGroup,
         add=True,
@@ -583,44 +458,9 @@ def patch_pas():
     )
     wrap_method(
         PluggableAuthService,
-        "getGroupByName",
-        getGroupByName,
-        add=True,
-        roles=PermissionRole(ManageUsers, ("Manager",)),
-    )
-    wrap_method(
-        PluggableAuthService,
-        "getGroupIds",
-        getGroupIds,
-        add=True,
-        roles=PermissionRole(ManageUsers, ("Manager",)),
-    )
-    wrap_method(
-        PluggableAuthService,
-        "getGroupNames",
-        getGroupNames,
-        add=True,
-        roles=PermissionRole(ManageUsers, ("Manager",)),
-    )
-    wrap_method(
-        PluggableAuthService,
-        "getGroups",
-        getGroups,
-        add=True,
-        roles=PermissionRole(ManageUsers, ("Manager",)),
-    )
-    wrap_method(
-        PluggableAuthService,
         "getLocalRolesForDisplay",
         getLocalRolesForDisplay,
         add=True,
-    )
-    wrap_method(
-        PluggableAuthService,
-        "getUserIds",
-        getUserIds,
-        add=True,
-        deprecated="Inefficient GRUF wrapper, use IUserIntrospection instead.",
     )
     wrap_method(
         PluggableAuthService,
@@ -638,13 +478,6 @@ def patch_pas():
     )
     wrap_method(
         PluggableAuthService,
-        "getPureUsers",
-        getUsers,
-        add=True,
-        roles=PermissionRole(ManageUsers, ("Manager",)),
-    )
-    wrap_method(
-        PluggableAuthService,
         "userFolderAddUser",
         postonly(userFolderAddUser),
         add=True,
@@ -653,14 +486,7 @@ def patch_pas():
     wrap_method(
         PluggableAuthService,
         "userFolderDelUsers",
-        postonly(_doDelUsers),
-        add=True,
-        roles=PermissionRole(ManageUsers, ("Manager",)),
-    )
-    wrap_method(
-        PluggableAuthService,
-        "userFolderEditGroup",
-        postonly(_doChangeGroup),
+        postonly(userFolderDelUsers),
         add=True,
         roles=PermissionRole(ManageUsers, ("Manager",)),
     )
@@ -668,13 +494,6 @@ def patch_pas():
         PluggableAuthService,
         "userFolderEditUser",
         postonly(_doChangeUser),
-        add=True,
-        roles=PermissionRole(ManageUsers, ("Manager",)),
-    )
-    wrap_method(
-        PluggableAuthService,
-        "userFolderDelGroups",
-        postonly(_doDelGroups),
         add=True,
         roles=PermissionRole(ManageUsers, ("Manager",)),
     )

--- a/src/Products/PlonePAS/tests/test_memberdatatool.py
+++ b/src/Products/PlonePAS/tests/test_memberdatatool.py
@@ -21,7 +21,7 @@ class TestMemberDataTool(unittest.TestCase):
         self.membership = self.portal.portal_membership
         self.membership.memberareaCreationFlag = 0
         # Don't let default_user disturb results
-        self.portal.acl_users._doDelUsers([default_user])
+        self.portal.acl_users.userFolderDelUsers([default_user])
         # Add some members
         self.addMember(
             "fred",

--- a/src/Products/PlonePAS/tests/test_membershiptool.py
+++ b/src/Products/PlonePAS/tests/test_membershiptool.py
@@ -837,7 +837,7 @@ class TestSearchForMembers(unittest.TestCase):
         self.memberdata = self.portal.portal_memberdata
         self.membership = self.portal.portal_membership
         # Don't let default_user disturb results
-        self.portal.acl_users._doDelUsers([TEST_USER_ID])
+        self.portal.acl_users.userFolderDelUsers([TEST_USER_ID])
         # Add some members
         self.addMember(
             "fred",

--- a/src/Products/PlonePAS/tools/groups.py
+++ b/src/Products/PlonePAS/tools/groups.py
@@ -378,7 +378,7 @@ class GroupsTool(UniqueObject, SimpleItem):
     def listGroupNames(self):
         """Return a list of the available groups' ids as entered
         (without group prefixes)."""
-        return self.acl_users.getGroupNames()
+        return self.getGroupIds()
 
     @security.public
     def isGroup(self, u):

--- a/src/Products/PlonePAS/tools/membership.py
+++ b/src/Products/PlonePAS/tools/membership.py
@@ -26,6 +26,7 @@ from Products.PlonePAS.events import UserInitialLoginInEvent
 from Products.PlonePAS.events import UserLoggedInEvent
 from Products.PlonePAS.events import UserLoggedOutEvent
 from Products.PlonePAS.interfaces import membership
+from Products.PlonePAS.interfaces.plugins import IUserIntrospection
 from Products.PlonePAS.utils import cleanId
 from Products.PlonePAS.utils import scale_image
 from zExceptions import BadRequest
@@ -530,7 +531,12 @@ class MembershipTool(BaseTool):
         replaced with a set of methods for querying pieces of the
         list rather than the entire list at once.
         """
-        return [user.getId() for user in self.acl_users.getUsers()]
+        results = []
+        for _iid, introspector in self.acl_users.plugins.listPlugins(
+            IUserIntrospection
+        ):
+            results.extend(introspector.getUserIds())
+        return results
 
     @security.protected(SetOwnPassword)
     def testCurrentPassword(self, password):

--- a/src/Products/PlonePAS/tools/membership.py
+++ b/src/Products/PlonePAS/tools/membership.py
@@ -530,7 +530,7 @@ class MembershipTool(BaseTool):
         replaced with a set of methods for querying pieces of the
         list rather than the entire list at once.
         """
-        return self.acl_users.getUserIds()
+        return [user.getId() for user in self.acl_users.getUsers()]
 
     @security.protected(SetOwnPassword)
     def testCurrentPassword(self, password):
@@ -574,12 +574,10 @@ class MembershipTool(BaseTool):
             if domains is None:
                 domains = []
             user = acl_users.getUserById(member.getUserId(), None)
-            # we must change the users password through grufs changepassword
-            # to keep her  group settings
             if hasattr(user, "changePassword"):
                 user.changePassword(password)
             else:
-                acl_users._doChangeUser(
+                acl_users.userFolderEditUser(
                     member.getUserId(), password, member.getRoles(), domains
                 )
             if REQUEST is None:

--- a/src/Products/PlonePAS/utils.py
+++ b/src/Products/PlonePAS/utils.py
@@ -180,12 +180,7 @@ def scale_image(image_file, max_size=None, default_format=None):
 def getGroupsForPrincipal(principal, plugins, request=None):
     groups = set()
     for iid, plugin in plugins.listPlugins(IGroupsPlugin):
-        try:
-            groups.update(plugin.getGroupsForPrincipal(principal, request))
-        except AttributeError:
-            # Some principals (e.g. anonymous SpecialUser) lack getGroups(),
-            # which plugins like RecursiveGroupsPlugin assume exists.
-            pass
+        groups.update(plugin.getGroupsForPrincipal(principal, request))
     return list(groups)
 
 

--- a/src/Products/PlonePAS/utils.py
+++ b/src/Products/PlonePAS/utils.py
@@ -180,7 +180,12 @@ def scale_image(image_file, max_size=None, default_format=None):
 def getGroupsForPrincipal(principal, plugins, request=None):
     groups = set()
     for iid, plugin in plugins.listPlugins(IGroupsPlugin):
-        groups.update(plugin.getGroupsForPrincipal(principal, request))
+        try:
+            groups.update(plugin.getGroupsForPrincipal(principal, request))
+        except AttributeError:
+            # Some principals (e.g. anonymous SpecialUser) lack getGroups(),
+            # which plugins like RecursiveGroupsPlugin assume exists.
+            pass
     return list(groups)
 
 


### PR DESCRIPTION
## Summary

- Remove 14 methods monkey-patched onto PAS by PlonePAS for GRUF (GroupUserFolder) backward compatibility
- Deprecate `getGroups` (cannot remove — used implicitly through Zope acquisition by `RecursiveGroupsPlugin`)
- All 14 removed methods have **zero callers** outside PlonePAS in the entire Plone 6 codebase
- Verified against actual GRUF source (`Products.GroupUserFolder 3.55.1` from PyPI)
- Fixes the first phase of #4

### Removed methods (14)

| Method | Origin | Notes |
|--------|--------|-------|
| `_doChangeGroup` | GRUF-only | Callers use `portal_groups.editGroup()` directly |
| `_doChangeUser` | Zope+GRUF | Zero external callers |
| `_doDelGroups` | GRUF-only | Callers use `portal_groups.removeGroup()` directly |
| `_doDelUsers` | Zope+GRUF | No Plone-level callers (only Zope infra) |
| `_updateGroup` | GRUF-only | Alias for `_doChangeGroup` |
| `addRole` | GRUF-only | In GRUF this was on user objects, not the folder |
| `getAllLocalRoles` | GRUF-only | Public wrapper; all code calls `_getAllLocalRoles` directly |
| `getGroupByName` | GRUF-only | Code uses `getGroupById` instead |
| `getGroupIds` | GRUF-only | Controlpanel has its own `getGroupIds` |
| `getGroupNames` | GRUF-only | Delegates to `portal_groups.getGroupIds()` anyway |
| `getPureUsers` | GRUF-only | Alias for `getUsers` |
| `getUserIds` | Zope+GRUF | Already marked deprecated |
| `userFolderEditGroup` | GRUF-only | Zero callers |
| `userFolderDelGroups` | GRUF-only | Zero callers |

### Deprecated (1)

| Method | Reason |
|--------|--------|
| `getGroups` | Used implicitly via Zope acquisition by `RecursiveGroupsPlugin` when resolving groups for principals without their own `getGroups` (e.g. anonymous `SpecialUser`). Use `portal_groups.listGroups()` instead. |

### Internal callers updated

- `membership.listMemberIds`: queries `IUserIntrospection` plugins directly instead of removed `getUserIds()`
- `membership.setPassword`: uses `userFolderEditUser()` instead of removed `_doChangeUser()`
- `groups.listGroupNames`: uses `self.getGroupIds()` instead of removed `acl_users.getGroupNames()`
- Tests: `_doDelUsers()` → `userFolderDelUsers()`

### What stays (not part of this PR)

Methods with callers that need migration paths are untouched:
`_doAddUser`, `_doAddGroup`, `_doDelUser`, `_delOb`, `_getAllLocalRoles`, `_getLocalRolesForDisplay`, `authenticate`, `canListAllGroups`, `canListAllUsers`, `credentialsChanged`, `getGroup`, `getGroupById`, `getLocalRolesForDisplay`, `getUserNames`, `getUsers`, `userFolderAddUser`, `userFolderDelUsers`, `userFolderEditUser`, `userSetGroups`, `userSetPassword`.

See the [full analysis](https://github.com/plone/Products.PlonePAS/issues/4#issuecomment-4129868783) for details.

## Test plan

- [x] All 173 PlonePAS tests pass
- [x] All pre-commit checks pass
- [x] `plone.api` `test_get_groups_anonymous` passes
- [ ] Jenkins CI green

🤖 Generated with [Claude Code](https://claude.ai/code)